### PR TITLE
feat: add computed_bldg_sqft reconciliation

### DIFF
--- a/src/homebuyer/api.py
+++ b/src/homebuyer/api.py
@@ -8,6 +8,7 @@ Usage:
     uvicorn homebuyer.api:app --port 8787
 """
 
+import asyncio
 import logging
 import os
 import re
@@ -501,18 +502,8 @@ class AppState:
         self.db.connect(check_same_thread=False)
         self.db.initialize_schema()
 
-        # Backfill computed_bldg_sqft for any rows that don't have it yet
-        from homebuyer.processing.reconcile_sqft import reconcile_sqft
-
-        try:
-            stats = reconcile_sqft(self.db)
-            logger.info(
-                "Sqft reconciliation: %d/%d properties populated.",
-                stats.get("_total_reconciled", 0),
-                stats.get("_total_properties", 0),
-            )
-        except Exception:
-            logger.exception("Sqft reconciliation failed (non-fatal).")
+        # Backfill computed_bldg_sqft — deferred to background in lifespan()
+        # to avoid blocking startup on large tables.
 
         logger.info("Loading ML model...")
         try:
@@ -710,6 +701,22 @@ async def lifespan(app: FastAPI):
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
     logger.info("Starting HomeBuyer API server...")
     _state = AppState()
+
+    # Run sqft reconciliation off the main thread so it doesn't block
+    # the event loop, but await completion before yielding to ensure
+    # the DB connection isn't closed while reconciliation is running.
+    try:
+        from homebuyer.processing.reconcile_sqft import reconcile_sqft
+
+        stats = await asyncio.to_thread(reconcile_sqft, _state.db)
+        logger.info(
+            "Sqft reconciliation: %d/%d properties populated.",
+            stats.get("_total_reconciled", 0),
+            stats.get("_total_properties", 0),
+        )
+    except Exception:
+        logger.exception("Sqft reconciliation failed (non-fatal).")
+
     # Generate fun facts at startup (non-blocking, non-fatal)
     try:
         from homebuyer.services.fun_facts import generate_fun_facts

--- a/src/homebuyer/api.py
+++ b/src/homebuyer/api.py
@@ -501,6 +501,19 @@ class AppState:
         self.db.connect(check_same_thread=False)
         self.db.initialize_schema()
 
+        # Backfill computed_bldg_sqft for any rows that don't have it yet
+        from homebuyer.processing.reconcile_sqft import reconcile_sqft
+
+        try:
+            stats = reconcile_sqft(self.db)
+            logger.info(
+                "Sqft reconciliation: %d/%d properties populated.",
+                stats.get("_total_reconciled", 0),
+                stats.get("_total_properties", 0),
+            )
+        except Exception:
+            logger.exception("Sqft reconciliation failed (non-fatal).")
+
         logger.info("Loading ML model...")
         try:
             self.model = ModelArtifact.load()

--- a/src/homebuyer/cli.py
+++ b/src/homebuyer/cli.py
@@ -533,29 +533,50 @@ def process_sales(ctx: click.Context) -> None:
 @process.command("all")
 @click.pass_context
 def process_all(ctx: click.Context) -> None:
-    """Run normalize, geocode, zoning, and deduplicate in sequence."""
-    click.echo("Step 1/5: Normalizing neighborhood names...")
+    """Run normalize, geocode, zoning, deduplicate, validate, and reconcile in sequence."""
+    click.echo("Step 1/6: Normalizing neighborhood names...")
     ctx.invoke(process_normalize)
 
-    click.echo("\nStep 2/5: Geocoding missing neighborhoods...")
+    click.echo("\nStep 2/6: Geocoding missing neighborhoods...")
     try:
         ctx.invoke(process_geocode)
     except FileNotFoundError as e:
         click.echo(f"  Skipping geocode: {e}")
 
-    click.echo("\nStep 3/5: Classifying zoning districts...")
+    click.echo("\nStep 3/6: Classifying zoning districts...")
     try:
         ctx.invoke(process_zoning)
     except FileNotFoundError as e:
         click.echo(f"  Skipping zoning: {e}")
 
-    click.echo("\nStep 4/5: Deduplicating records...")
+    click.echo("\nStep 4/6: Deduplicating records...")
     ctx.invoke(process_deduplicate)
 
-    click.echo("\nStep 5/5: Validating data ranges...")
+    click.echo("\nStep 5/6: Validating data ranges...")
     ctx.invoke(process_validate)
 
+    click.echo("\nStep 6/6: Reconciling building sqft...")
+    ctx.invoke(process_reconcile_sqft)
+
     click.echo("\nAll processing complete.")
+
+
+@process.command("reconcile-sqft")
+@click.option("--force", is_flag=True, help="Re-reconcile all rows (clears existing values).")
+@click.pass_context
+def process_reconcile_sqft(ctx: click.Context, force: bool = False) -> None:
+    """Reconcile building_sqft vs sqft into computed_bldg_sqft."""
+    from homebuyer.processing.reconcile_sqft import reconcile_sqft
+
+    db_path = ctx.obj["db_path"]
+    with Database(db_path) as db:
+        db.initialize_schema()
+        stats = reconcile_sqft(db, force=force)
+
+    total = stats.get("_total_reconciled", 0)
+    noted = stats.get("_total_noted", 0)
+    props = stats.get("_total_properties", 0)
+    click.echo(f"Reconciled: {total}/{props} properties, {noted} with data notes")
 
 
 # ---------------------------------------------------------------------------

--- a/src/homebuyer/cli.py
+++ b/src/homebuyer/cli.py
@@ -562,7 +562,7 @@ def process_all(ctx: click.Context) -> None:
 
 
 @process.command("reconcile-sqft")
-@click.option("--force", is_flag=True, help="Re-reconcile all rows (clears existing values).")
+@click.option("--force", is_flag=True, help="Re-reconcile all rows (clears computed_bldg_sqft and data_notes, then regenerates both).")
 @click.pass_context
 def process_reconcile_sqft(ctx: click.Context, force: bool = False) -> None:
     """Reconcile building_sqft vs sqft into computed_bldg_sqft."""

--- a/src/homebuyer/processing/reconcile_sqft.py
+++ b/src/homebuyer/processing/reconcile_sqft.py
@@ -1,0 +1,209 @@
+"""Reconcile building_sqft vs sqft into computed_bldg_sqft.
+
+The properties table has two building-size columns from different sources:
+- building_sqft: assessor-reported total building footprint
+- sqft: third-party (RentCast/MLS) per-unit living area
+
+These conflict for ~4000+ rows.  This module applies category-based rules
+to pick the best value and writes it to computed_bldg_sqft, recording the
+reasoning in data_notes (a JSON array).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from homebuyer.storage.database import Database
+
+logger = logging.getLogger(__name__)
+
+# Each rule is: (label, WHERE clause, computed value SQL, note text)
+# Rules are evaluated top-to-bottom; earlier rules take priority because
+# each UPDATE only touches rows where computed_bldg_sqft IS STILL NULL.
+_RECONCILIATION_RULES: list[tuple[str, str, str, str]] = [
+    # --- Fake vacants (building_sqft = 0 but property clearly exists) ---
+    (
+        "S1: Fake vacant with rooms",
+        """building_sqft = 0
+           AND sqft > 0
+           AND (beds > 0 OR baths > 0)""",
+        "sqft",
+        "Assessor reports 0 bldg sqft but property has beds/baths; using third-party sqft",
+    ),
+    (
+        "S2: Fake vacant sqft-only",
+        """building_sqft = 0
+           AND sqft > 0
+           AND (beds IS NULL OR beds = 0)
+           AND (baths IS NULL OR baths = 0)""",
+        "sqft",
+        "Assessor reports 0 bldg sqft; using third-party sqft as fallback",
+    ),
+    # --- Condo-specific (building_sqft often = whole building, sqft = per-unit) ---
+    (
+        "S3: Condo bldg = whole building",
+        """property_category IN ('condo', 'coop', 'townhouse')
+           AND building_sqft > 0 AND sqft > 0
+           AND building_sqft > sqft * 3""",
+        "sqft",
+        "Assessor building_sqft appears to be whole-building total; using per-unit sqft",
+    ),
+    (
+        "S4: Condo sqft = whole building",
+        """property_category IN ('condo', 'coop', 'townhouse')
+           AND building_sqft > 0 AND sqft > 0
+           AND sqft > building_sqft * 3""",
+        "building_sqft",
+        "Third-party sqft appears to be whole-building total; using assessor building_sqft",
+    ),
+    (
+        "S5: Condo moderate bldg > sqft",
+        """property_category IN ('condo', 'coop', 'townhouse')
+           AND building_sqft > 0 AND sqft > 0
+           AND building_sqft > sqft""",
+        "sqft",
+        "Condo building_sqft > unit sqft; using per-unit sqft",
+    ),
+    (
+        "S6: Condo moderate sqft > bldg",
+        """property_category IN ('condo', 'coop', 'townhouse')
+           AND building_sqft > 0 AND sqft > 0
+           AND sqft > building_sqft""",
+        "sqft",
+        "Condo sqft > building_sqft; using larger per-unit sqft",
+    ),
+    # --- Non-condo mismatches ---
+    (
+        "S8: Non-condo bldg > sqft",
+        """property_category NOT IN ('condo', 'coop', 'townhouse')
+           AND building_sqft > 0 AND sqft > 0
+           AND building_sqft > sqft""",
+        "building_sqft",
+        "Assessor building_sqft > third-party sqft; using assessor value",
+    ),
+    (
+        "S9: Non-condo sqft > bldg",
+        """property_category NOT IN ('condo', 'coop', 'townhouse')
+           AND building_sqft > 0 AND sqft > 0
+           AND sqft > building_sqft""",
+        "sqft",
+        "Third-party sqft > assessor building_sqft; using larger value",
+    ),
+    # --- Single-source rows ---
+    (
+        "S10: Not enriched (bldg only)",
+        """building_sqft > 0
+           AND (sqft IS NULL OR sqft = 0)""",
+        "building_sqft",
+        "No third-party data; using assessor building_sqft",
+    ),
+    (
+        "S11: No data at all",
+        """(building_sqft IS NULL OR building_sqft = 0)
+           AND (sqft IS NULL OR sqft = 0)""",
+        "NULL",
+        "No building sqft data from any source",
+    ),
+    # --- Happy path: both agree ---
+    (
+        "OK: Match",
+        """building_sqft > 0 AND sqft > 0
+           AND building_sqft = sqft""",
+        "sqft",
+        None,  # no note needed — sources agree
+    ),
+    (
+        "OK: Only sqft",
+        """(building_sqft IS NULL OR building_sqft = 0)
+           AND sqft > 0""",
+        "sqft",
+        None,
+    ),
+]
+
+
+def reconcile_sqft(db: Database, *, force: bool = False) -> dict[str, int]:
+    """Populate computed_bldg_sqft and data_notes for all properties.
+
+    Parameters
+    ----------
+    db : Database
+        Connected database instance.
+    force : bool
+        If True, re-reconcile all rows (clears computed_bldg_sqft first).
+        If False (default), only touches rows where computed_bldg_sqft IS NULL.
+
+    Returns
+    -------
+    dict mapping rule label → number of rows updated.
+    """
+    if force:
+        db.execute("UPDATE properties SET computed_bldg_sqft = NULL, data_notes = NULL")
+        db.commit()
+        logger.info("Force mode: cleared computed_bldg_sqft and data_notes.")
+
+    stats: dict[str, int] = {}
+
+    for label, where, value_expr, note_text in _RECONCILIATION_RULES:
+        # Count matching rows before update (to measure impact)
+        pre_count = db.fetchval(
+            f"SELECT COUNT(*) FROM properties WHERE computed_bldg_sqft IS NULL AND {where}"
+        ) or 0
+
+        if pre_count == 0:
+            stats[label] = 0
+            continue
+
+        if note_text is not None:
+            note_json = json.dumps([note_text])
+            sql = f"""
+                UPDATE properties
+                SET computed_bldg_sqft = {value_expr},
+                    data_notes = CASE
+                        WHEN data_notes IS NULL THEN ?
+                        ELSE data_notes
+                    END
+                WHERE computed_bldg_sqft IS NULL
+                  AND {where}
+            """
+            db.execute(sql, (note_json,))
+        else:
+            # No note needed (happy path)
+            sql = f"""
+                UPDATE properties
+                SET computed_bldg_sqft = {value_expr}
+                WHERE computed_bldg_sqft IS NULL
+                  AND {where}
+            """
+            db.execute(sql)
+
+        db.commit()
+        stats[label] = pre_count
+
+        if pre_count > 0:
+            logger.info("  %s: %d rows", label, pre_count)
+
+    # Summary
+    total_reconciled = db.fetchval(
+        "SELECT COUNT(*) FROM properties WHERE computed_bldg_sqft IS NOT NULL"
+    ) or 0
+    total_noted = db.fetchval(
+        "SELECT COUNT(*) FROM properties WHERE data_notes IS NOT NULL"
+    ) or 0
+    total_props = db.fetchval("SELECT COUNT(*) FROM properties") or 0
+
+    logger.info(
+        "Reconciliation complete: %d/%d properties have computed_bldg_sqft, "
+        "%d have data_notes.",
+        total_reconciled,
+        total_props,
+        total_noted,
+    )
+
+    stats["_total_reconciled"] = total_reconciled
+    stats["_total_noted"] = total_noted
+    stats["_total_properties"] = total_props
+    return stats

--- a/src/homebuyer/processing/reconcile_sqft.py
+++ b/src/homebuyer/processing/reconcile_sqft.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 # Each rule is: (label, WHERE clause, computed value SQL, note text)
 # Rules are evaluated top-to-bottom; earlier rules take priority because
 # each UPDATE only touches rows where computed_bldg_sqft IS STILL NULL.
+#
+# data_notes is assumed to be a JSON array (or NULL).  The SQL CASE
+# expression only writes notes when data_notes IS NULL; existing non-null
+# values are preserved as-is.  If a row has malformed JSON in data_notes,
+# it will be left untouched — this is intentional to avoid data loss.
 _RECONCILIATION_RULES: list[tuple[str, str, str, str]] = [
     # --- Fake vacants (building_sqft = 0 but property clearly exists) ---
     (
@@ -76,6 +81,8 @@ _RECONCILIATION_RULES: list[tuple[str, str, str, str]] = [
         "Condo sqft > building_sqft; using larger per-unit sqft",
     ),
     # --- Non-condo mismatches ---
+    # S7 was removed: it handled condo equal-value cases (building_sqft == sqft)
+    # which are now caught by the "OK: Match" happy-path rule below.
     (
         "S8: Non-condo bldg > sqft",
         """property_category NOT IN ('condo', 'coop', 'townhouse')
@@ -133,7 +140,7 @@ def reconcile_sqft(db: Database, *, force: bool = False) -> dict[str, int]:
     db : Database
         Connected database instance.
     force : bool
-        If True, re-reconcile all rows (clears computed_bldg_sqft first).
+        If True, re-reconcile all rows (clears computed_bldg_sqft and data_notes, then regenerates both).
         If False (default), only touches rows where computed_bldg_sqft IS NULL.
 
     Returns

--- a/src/homebuyer/storage/database.py
+++ b/src/homebuyer/storage/database.py
@@ -916,17 +916,6 @@ class Database:
                     "Migration v4: renamed attom_enriched → rentcast_enriched."
                 )
 
-            # --- v6 migration: add computed_bldg_sqft + data_notes ---
-            if "computed_bldg_sqft" not in props_cols:
-                self.execute(
-                    "ALTER TABLE properties ADD COLUMN computed_bldg_sqft INTEGER"
-                )
-                self.execute("ALTER TABLE properties ADD COLUMN data_notes TEXT")
-                self.commit()
-                logger.info(
-                    "Migration v6: added computed_bldg_sqft and data_notes columns."
-                )
-
         # --- v3 migration: make password_hash nullable for OAuth-only users ---
         if self.table_exists("users") and not self.is_postgres:
             # SQLite doesn't support ALTER COLUMN, so recreate table if needed
@@ -961,6 +950,22 @@ class Database:
                 # Re-enable FK enforcement
                 self.conn.execute("PRAGMA foreign_keys=ON")
                 logger.info("Migration v3: users table recreated with nullable password_hash.")
+
+        # --- v6 migration: add computed_bldg_sqft + data_notes ---
+        if self.table_exists("properties"):
+            props_cols_v6 = self.get_table_columns("properties")
+            if "computed_bldg_sqft" not in props_cols_v6:
+                self.execute(
+                    "ALTER TABLE properties ADD COLUMN computed_bldg_sqft INTEGER"
+                )
+                self.commit()
+                logger.info("Migration v6: added computed_bldg_sqft column.")
+            if "data_notes" not in props_cols_v6:
+                self.execute(
+                    "ALTER TABLE properties ADD COLUMN data_notes TEXT"
+                )
+                self.commit()
+                logger.info("Migration v6: added data_notes column.")
 
         # --- Create/update schema ---
         if self.is_postgres:

--- a/src/homebuyer/storage/database.py
+++ b/src/homebuyer/storage/database.py
@@ -53,7 +53,7 @@ def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 # Schema DDL (SQLite dialect — translated at runtime for Postgres)
 # ---------------------------------------------------------------------------
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 _SCHEMA_SQL_SQLITE = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -243,6 +243,8 @@ CREATE TABLE IF NOT EXISTS properties (
     record_type         TEXT,
     lot_group_key       TEXT,
     parcel_lot_size_sqft INTEGER,
+    computed_bldg_sqft  INTEGER,
+    data_notes          TEXT,
     collected_at        TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -912,6 +914,17 @@ class Database:
                 self.commit()
                 logger.info(
                     "Migration v4: renamed attom_enriched → rentcast_enriched."
+                )
+
+            # --- v6 migration: add computed_bldg_sqft + data_notes ---
+            if "computed_bldg_sqft" not in props_cols:
+                self.execute(
+                    "ALTER TABLE properties ADD COLUMN computed_bldg_sqft INTEGER"
+                )
+                self.execute("ALTER TABLE properties ADD COLUMN data_notes TEXT")
+                self.commit()
+                logger.info(
+                    "Migration v6: added computed_bldg_sqft and data_notes columns."
                 )
 
         # --- v3 migration: make password_hash nullable for OAuth-only users ---

--- a/src/homebuyer/storage/models.py
+++ b/src/homebuyer/storage/models.py
@@ -1,5 +1,6 @@
 """Data models for the HomeBuyer application."""
 
+import json
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import Optional
@@ -196,7 +197,18 @@ class BerkeleyParcel:
     rentcast_enriched: bool = False  # Flag: has RentCast API enrichment been fetched?
     # Computed / reconciled fields
     computed_bldg_sqft: Optional[int] = None  # Best-available building sqft after reconciliation
-    data_notes: Optional[str] = None  # JSON array of reconciliation notes
+    data_notes: Optional[str] = None  # JSON array of reconciliation notes (use notes_list property)
+
+    @property
+    def notes_list(self) -> list[str]:
+        """Parse data_notes JSON string into a list of strings."""
+        if not self.data_notes:
+            return []
+        try:
+            parsed = json.loads(self.data_notes)
+            return parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, TypeError):
+            return []
 
 
 @dataclass

--- a/src/homebuyer/storage/models.py
+++ b/src/homebuyer/storage/models.py
@@ -194,6 +194,9 @@ class BerkeleyParcel:
     last_sale_date: Optional[str] = None
     last_sale_price: Optional[int] = None
     rentcast_enriched: bool = False  # Flag: has RentCast API enrichment been fetched?
+    # Computed / reconciled fields
+    computed_bldg_sqft: Optional[int] = None  # Best-available building sqft after reconciliation
+    data_notes: Optional[str] = None  # JSON array of reconciliation notes
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Adds `computed_bldg_sqft` and `data_notes` columns to properties table (schema v5→v6)
- 12 category-based rules reconcile conflicting `building_sqft` (assessor) vs `sqft` (RentCast/MLS) into a single best value
- 24,853/25,263 properties reconciled; 4,466 flagged with explanatory notes
- Auto-runs on app startup; also available via `homebuyer process reconcile-sqft [--force]`

## Test plan
- [x] 1022 tests pass
- [x] Migration verified on local SQLite (columns created, data populated)
- [x] Zero unreconciled rows where data exists
- [ ] Verify migration runs on production PostgreSQL after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)